### PR TITLE
Introduce long-range-reducer with support of marker

### DIFF
--- a/test/exoscale/vinyl/scan_test.clj
+++ b/test/exoscale/vinyl/scan_test.clj
@@ -70,6 +70,20 @@
                                       [:Object [:and
                                                 [:= :bucket "small-bucket"]
                                                 [:starts-with? :path "files/00000010.txt"]]]))))
+    (is (= 100
+           @(store/long-range-reducer *db* incrementor 0 :Object ["small-bucket"])))
+
+    (is (= 100
+           @(store/long-range-reducer *db* incrementor 0 :Object ["small-bucket" ""])))
+
+    (is (= 100
+           @(store/long-range-reducer *db* incrementor 0 :Object ["small-bucket" "files/"])))
+
+    (is (= 90
+           @(store/long-range-reducer *db* incrementor 0 :Object ["small-bucket" "files/"] {::store/marker "files/00000010.txt"})))
+
+    (is (= 90
+           @(store/long-range-reducer *db* incrementor 0 :Object ["small-bucket" ""] {::store/marker "files/00000010.txt"})))
 
   (testing "returning a `reduced` value stops iteration"
     (is (= 10


### PR DESCRIPTION
This PR introduces `long-range-reducer` which optionnally with the support of a `marker` parameter.