### PR TITLE
fdb: upgrade library version to 6.3.15

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
 
   :dependencies [[org.clojure/clojure                        "1.10.3"]
                  [org.clojure/tools.logging                  "1.1.0"]
+                 [org.foundationdb/fdb-java                  "6.3.15"]
                  [org.foundationdb/fdb-record-layer-core-pb3 "2.8.110.0"]
                  [com.google.protobuf/protobuf-java          "3.15.8"]
                  [com.stuartsierra/component                 "1.0.0"]


### PR DESCRIPTION
To match our latest `store-fdb` cluster version. A PR to `exoscale/sos` will follow shortly