### PR TITLE
 store: Adding long-range support for multi-field primary-keys 

### DIFF
--- a/src/exoscale/vinyl/store.clj
+++ b/src/exoscale/vinyl/store.clj
@@ -345,11 +345,12 @@
       (all-of-range txn-context record-type fixed))))
 
 (defn ^TupleRange continuation-range
-  "Given a prefix and an optional continuation, return a TupleRange catching all
-   elements with the given prefix, starting from continuation if present."
-  [txn-context record-type items continuations continuation]
-  (if (or (seq continuations) continuation)
-    (let [tuple-start (key-for* txn-context record-type (conj (vec (concat (butlast items) continuations)) continuation))
+  "Given a prefix and an optional continuation, both being a collection of
+   keys, return a TupleRange catching all elements with the given prefix, starting
+   from continuation if present."
+  [txn-context record-type items continuation]
+  (if (seq continuation)
+    (let [tuple-start (key-for* txn-context record-type (vec (concat (butlast items) continuation)))
           tuple-end   (key-for* txn-context record-type (vec items))]
       (TupleRange.
         tuple-start
@@ -505,8 +506,8 @@
    taken with the accumulator."
   ([db f val record-type items]
    (long-range-reduce db f val record-type items {}))
-  ([db f val record-type items {::keys [continuations continuation] :as opts}]
-   (let [range (continuation-range db record-type items continuations continuation)
+  ([db f val record-type items {::keys [continuation] :as opts}]
+   (let [range (continuation-range db record-type items continuation)
          props (scan-properties opts)]
      (continuation-traversing-transduce
       db nil f val
@@ -518,8 +519,8 @@
    behaves like `long-range-reducer`."
   ([db xform f val record-type items]
    (long-range-transduce db xform f val record-type items {}))
-  ([db xform f val record-type items {::keys [continuations continuation] :as opts}]
-   (let [range (continuation-range db record-type items continuations continuation)
+  ([db xform f val record-type items {::keys [continuation] :as opts}]
+   (let [range (continuation-range db record-type items continuation)
          props (scan-properties opts)]
      (continuation-traversing-transduce
       db xform f val

--- a/src/exoscale/vinyl/store.clj
+++ b/src/exoscale/vinyl/store.clj
@@ -347,9 +347,9 @@
 (defn ^TupleRange continuation-range
   "Given a prefix and an optional continuation, return a TupleRange catching all
    elements with the given prefix, starting from continuation if present."
-  [txn-context record-type items continuation]
-  (if continuation
-    (let [tuple-start (key-for* txn-context record-type (conj (vec (butlast items)) continuation))
+  [txn-context record-type items continuations continuation]
+  (if (or (seq continuations) continuation)
+    (let [tuple-start (key-for* txn-context record-type (conj (vec (concat (butlast items) continuations)) continuation))
           tuple-end   (key-for* txn-context record-type (vec items))]
       (TupleRange.
         tuple-start
@@ -505,8 +505,8 @@
    taken with the accumulator."
   ([db f val record-type items]
    (long-range-reduce db f val record-type items {}))
-  ([db f val record-type items {::keys [continuation] :as opts}]
-   (let [range (continuation-range db record-type items continuation)
+  ([db f val record-type items {::keys [continuations continuation] :as opts}]
+   (let [range (continuation-range db record-type items continuations continuation)
          props (scan-properties opts)]
      (continuation-traversing-transduce
       db nil f val
@@ -518,8 +518,8 @@
    behaves like `long-range-reducer`."
   ([db xform f val record-type items]
    (long-range-transduce db xform f val record-type items {}))
-  ([db xform f val record-type items {::keys [continuation] :as opts}]
-   (let [range (continuation-range db record-type items continuation)
+  ([db xform f val record-type items {::keys [continuations continuation] :as opts}]
+   (let [range (continuation-range db record-type items continuations continuation)
          props (scan-properties opts)]
      (continuation-traversing-transduce
       db xform f val

--- a/test/exoscale/vinyl/scan_test.clj
+++ b/test/exoscale/vinyl/scan_test.clj
@@ -57,24 +57,13 @@
     (is (= [{:id 3, :location {:name "Lausanne", :zip-code 1002}}
             {:id 4, :location {:name "Lausanne", :zip-code 1003}}
             {:id 5, :location {:name "Lausanne", :zip-code 1004}}]
-           @(store/long-range-transduce *db* (map p/parse-record) (completing conj) [] :City ["Lausanne" nil] {::store/continuation 1002})))
-
-    (is (= [{:id 3, :location {:name "Lausanne", :zip-code 1002}}
-            {:id 4, :location {:name "Lausanne", :zip-code 1003}}
-            {:id 5, :location {:name "Lausanne", :zip-code 1004}}]
-           @(store/long-range-transduce *db* (map p/parse-record) (completing conj) [] :City ["Lausanne" nil] {::store/continuations [1002]})))
+           @(store/long-range-transduce *db* (map p/parse-record) (completing conj) [] :City ["Lausanne" nil] {::store/continuation [1002]})))
 
     (is (= [{:id 3, :location {:name "Lausanne", :zip-code 1002}}
             {:id 4, :location {:name "Lausanne", :zip-code 1003}}
             {:id 5, :location {:name "Lausanne", :zip-code 1004}}
             {:id 6, :location {:name "Neuchatel", :zip-code 2000}}]
-           @(store/long-range-transduce *db* (map p/parse-record) (completing conj) [] :City [""] {::store/continuations ["Lausanne" 1002]})))
-
-    (is (= [{:id 3, :location {:name "Lausanne", :zip-code 1002}}
-            {:id 4, :location {:name "Lausanne", :zip-code 1003}}
-            {:id 5, :location {:name "Lausanne", :zip-code 1004}}
-            {:id 6, :location {:name "Neuchatel", :zip-code 2000}}]
-           @(store/long-range-transduce *db* (map p/parse-record) (completing conj) [] :City [""] {::store/continuations ["Lausanne"] ::store/continuation 1002})))))
+           @(store/long-range-transduce *db* (map p/parse-record) (completing conj) [] :City [""] {::store/continuation ["Lausanne" 1002]})))))
 
 (deftest large-range-scan-test-on-small-data
 
@@ -117,10 +106,10 @@
            @(store/long-range-reduce *db* incrementor 0 :Object ["small-bucket" "files/"])))
 
     (is (= 90
-           @(store/long-range-reduce *db* incrementor 0 :Object ["small-bucket" "files/"] {::store/continuation "files/00000010.txt"})))
+           @(store/long-range-reduce *db* incrementor 0 :Object ["small-bucket" "files/"] {::store/continuation ["files/00000010.txt"]})))
 
     (is (= 90
-           @(store/long-range-reduce *db* incrementor 0 :Object ["small-bucket" ""] {::store/continuation "files/00000010.txt"})))
+           @(store/long-range-reduce *db* incrementor 0 :Object ["small-bucket" ""] {::store/continuation ["files/00000010.txt"]})))
 
     (testing "returning a `reduced` value stops iteration"
       (is (= 10
@@ -165,9 +154,7 @@
     (is (= 40
            @(store/long-range-reduce *db* incrementor 0 :Object ["bucket-"])))
     (is (= 30
-           @(store/long-range-reduce *db* incrementor 0 :Object ["bucket-"] {::store/continuations ["bucket-66" "files/00000010.txt"]})))
-    (is (= 30
-           @(store/long-range-reduce *db* incrementor 0 :Object ["bucket-"] {::store/continuations ["bucket-66"] ::store/continuation "files/00000010.txt"})))
+           @(store/long-range-reduce *db* incrementor 0 :Object ["bucket-"] {::store/continuation ["bucket-66" "files/00000010.txt"]})))
 
     (doseq [bucket ["bucket-66" "bucket-666"]]
       (is (= 20
@@ -177,10 +164,10 @@
              @(store/long-range-reduce *db* incrementor 0 :Object [bucket nil])))
 
       (is (= 15
-             @(store/long-range-reduce *db* incrementor 0 :Object [bucket nil] {::store/continuation "files/00000005.txt"})))
+             @(store/long-range-reduce *db* incrementor 0 :Object [bucket nil] {::store/continuation ["files/00000005.txt"]})))
 
       (is (= 0
-             @(store/long-range-reduce *db* incrementor 0 :Object [bucket nil] {::store/continuation "files/66666666.txt"})))
+             @(store/long-range-reduce *db* incrementor 0 :Object [bucket nil] {::store/continuation ["files/66666666.txt"]})))
 
       (is (= 10
              @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000000"])))
@@ -189,16 +176,16 @@
              @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000001"])))
 
       (is (= 5
-             @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000000"] {::store/continuation "files/00000005.txt"})))
+             @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000000"] {::store/continuation ["files/00000005.txt"]})))
 
       (is (= 5
-             @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000001"] {::store/continuation "files/00000015.txt"})))
+             @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000001"] {::store/continuation ["files/00000015.txt"]})))
 
       (is (thrown? java.util.concurrent.ExecutionException
-             @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000000"] {::store/continuation "files/00000015.txt"})))
+             @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000000"] {::store/continuation ["files/00000015.txt"]})))
 
       (is (thrown? java.util.concurrent.ExecutionException
-             @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000001"] {::store/continuation "files/00000005.txt"}))))))
+             @(store/long-range-reduce *db* incrementor 0 :Object [bucket "files/0000001"] {::store/continuation ["files/00000005.txt"]}))))))
 
 (comment
 


### PR DESCRIPTION
## Description

This PR will allow to use long-range-{transduce,reduce} over a "table", using multiple continuation tokens, when the primary-key is the concatenation of multiple fields.

## Testing done
```
$ lein test 2>&1 | tee test.log
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.

lein test exoscale.vinyl.cursor-test

lein test exoscale.vinyl.demostore

lein test exoscale.vinyl.payload

lein test exoscale.vinyl.payload-test
{:result true, :num-tests 100, :seed 1655276128553, :time-elapsed-ms 39, :test-var "user-serialization-test"}
{:result true, :num-tests 100, :seed 1655276128596, :time-elapsed-ms 136, :test-var "invoice-serialization-test"}
{:result true, :num-tests 100, :seed 1655276128733, :time-elapsed-ms 19, :test-var "account-serialization-test"}

lein test exoscale.vinyl.scan-test
[main] INFO exoscale.vinyl.store - started store :demostore / testing5359
[main] INFO exoscale.vinyl.demostore - installing test data: 23 records
[main] INFO exoscale.vinyl.demostore - ready to serve fdb queries
[main] INFO exoscale.vinyl.demostore - cleaning fdb store

lein test exoscale.vinyl.sql-test
[main] INFO exoscale.vinyl.store - started store :demostore / testing5360
[main] INFO exoscale.vinyl.demostore - installing test data: 23 records
[main] INFO exoscale.vinyl.demostore - ready to serve fdb queries
[main] INFO exoscale.vinyl.demostore - cleaning fdb store

lein test exoscale.vinyl.store-test
[main] INFO exoscale.vinyl.store - started store :demostore / testing5361
[main] INFO exoscale.vinyl.demostore - installing test data: 23 records
[main] INFO exoscale.vinyl.demostore - ready to serve fdb queries
[main] INFO exoscale.vinyl.demostore - cleaning fdb store

Ran 13 tests containing 88 assertions.
0 failures, 0 errors.
```

