### PR TITLE
Introduce raw parameter to return FDB KeyValue

### DIFF
--- a/src/exoscale/vinyl/tuple.clj
+++ b/src/exoscale/vinyl/tuple.clj
@@ -9,6 +9,10 @@
   ^Tuple [objs]
   (Tuple/from (into-array Object objs)))
 
+(defn from-bytes
+  ^Tuple [^bytes bytes]
+  (Tuple/fromBytes bytes))
+
 (defn from
   ^Tuple [& objs]
   (from-seq objs))


### PR DESCRIPTION
## Description

This PR leverages FoundationDB Java API to return `com.apple.foundationdb.KeyValue` (key as bytes, value as bytes)
by adding a `raw?` parameter to `long-range-reduce` and `long-range-transduce`.
It allows performing reduction with minimal overhead (under the hood, it uses the blocking Java API).