### PR TITLE
Fix reduced for apply-iterable-transduce

### DIFF
--- a/src/exoscale/vinyl/cursor.clj
+++ b/src/exoscale/vinyl/cursor.clj
@@ -63,12 +63,11 @@
 
      ;; Using the blocking API is actually faster than using the non-blocking
      ;; one (2 times faster according to naive benchmarks)
-     (while (.hasNext iterator)
+     (while (and (not (reduced? @acc)) (.hasNext iterator))
        (let [key-value ^KeyValue (.next iterator)]
          (when (ifn? cont-fn)
            (-> key-value .getKey cont-fn))
-         (let [new-acc (swap! acc reducer key-value)]
-           (not (reduced? new-acc)))))
+         (swap! acc reducer key-value)))
 
      (CompletableFuture/completedFuture
       (unreduced (cond-> @acc

--- a/test/exoscale/vinyl/scan_test.clj
+++ b/test/exoscale/vinyl/scan_test.clj
@@ -94,11 +94,11 @@
                                                                                                         ::store/limit 2
                                                                                                         ::store/continuation ["Lausannf"]}))))
     (testing "we get back expected values with a early reduced reducer"
-     (is (= [{:name "Lausanne", :zip-code 1000}
-             {:name "Lausanne", :zip-code 1001}
-             {:name "Lausanne", :zip-code 1002}
-             {:name "Lausanne", :zip-code 1003}]
-            @(store/long-range-transduce *db* city-key-xf (completing city-key-reduced-reducer) [] :City [""] {::store/raw? true}))))))
+      (is (= [{:name "Lausanne", :zip-code 1000}
+              {:name "Lausanne", :zip-code 1001}
+              {:name "Lausanne", :zip-code 1002}
+              {:name "Lausanne", :zip-code 1003}]
+             @(store/long-range-transduce *db* city-key-xf (completing city-key-reduced-reducer) [] :City [""] {::store/raw? true}))))))
 
 (deftest large-range-scan-test-on-small-data
 

--- a/test/exoscale/vinyl/scan_test.clj
+++ b/test/exoscale/vinyl/scan_test.clj
@@ -66,11 +66,15 @@
            @(store/long-range-transduce *db* (map p/parse-record) (completing conj) [] :City [""] {::store/continuation ["Lausanne" 1002]})))))
 
 (deftest large-range-scan-over-raw-key-values
-  (let [city-key-xf (comp (map #(.getKey %))
-                          (map tuple/from-bytes)
-                          (map (juxt #(tuple/get-string % 4) #(tuple/get-long % 5))))
-        city-key-reducer (fn [acc [name zip-code]]
-                           (conj acc {:name name :zip-code zip-code}))]
+  (let [city-key-xf              (comp (map #(.getKey %))
+                                       (map tuple/from-bytes)
+                                       (map (juxt #(tuple/get-string % 4) #(tuple/get-long % 5))))
+        city-key-reducer         (fn [acc [name zip-code]]
+                                   (conj acc {:name name :zip-code zip-code}))
+        city-key-reduced-reducer (fn [acc [name zip-code]]
+                                   (cond-> (conj acc {:name name :zip-code zip-code})
+                                     (= 1003 zip-code) (reduced)))]
+
     (testing "we get back expected values"
       (is (= [{:name "Lausanne", :zip-code 1000}
               {:name "Lausanne", :zip-code 1001}
@@ -88,7 +92,13 @@
       (is (= [{:name "Neuchatel", :zip-code 2000}]
              @(store/long-range-transduce *db* city-key-xf (completing city-key-reducer) [] :City [""] {::store/raw? true
                                                                                                         ::store/limit 2
-                                                                                                        ::store/continuation ["Lausannf"]}))))))
+                                                                                                        ::store/continuation ["Lausannf"]}))))
+    (testing "we get back expected values with a early reduced reducer"
+     (is (= [{:name "Lausanne", :zip-code 1000}
+             {:name "Lausanne", :zip-code 1001}
+             {:name "Lausanne", :zip-code 1002}
+             {:name "Lausanne", :zip-code 1003}]
+            @(store/long-range-transduce *db* city-key-xf (completing city-key-reduced-reducer) [] :City [""] {::store/raw? true}))))))
 
 (deftest large-range-scan-test-on-small-data
 

--- a/test/exoscale/vinyl/scan_test.clj
+++ b/test/exoscale/vinyl/scan_test.clj
@@ -93,7 +93,7 @@
              @(store/long-range-transduce *db* city-key-xf (completing city-key-reducer) [] :City [""] {::store/raw? true
                                                                                                         ::store/limit 2
                                                                                                         ::store/continuation ["Lausannf"]}))))
-    (testing "we get back expected values with a early reduced reducer"
+    (testing "we get back expected values with an early reduced reducer"
       (is (= [{:name "Lausanne", :zip-code 1000}
               {:name "Lausanne", :zip-code 1001}
               {:name "Lausanne", :zip-code 1002}


### PR DESCRIPTION
## Description

This ensures `apply-iterable-transduce` supports a reducer using `reduced`.