### PR TITLE
delete-by-range: remove run-async

### DIFF
--- a/src/exoscale/vinyl/store.clj
+++ b/src/exoscale/vinyl/store.clj
@@ -471,7 +471,7 @@
 (defn delete-by-range
   [txn-context ^TupleRange range]
   (let [callback (fn [store] #(delete-record store (record-primary-key %)))]
-    (run-async txn-context #(scan-range % range {::foreach (callback %)}))))
+    (scan-range txn-context range {::foreach (callback txn-context)})))
 
 (defn delete-by-prefix-scan
   "Delete all records surfaced by a prefix scan. Beware that prefixes are


### PR DESCRIPTION
scan-range is already executed via `run-async`
=> no need to wrap it in a `run-async` call