### PR TITLE
db-from-instance: add support for blocking-in-async-detection

### DIFF
--- a/src/exoscale/vinyl/store.clj
+++ b/src/exoscale/vinyl/store.clj
@@ -97,7 +97,7 @@
 (defn- blocking-in-async-detection-mode [kw]
   (get -blocking-in-async-detection-modes kw BlockingInAsyncDetection/DISABLED))
 
-(defn- default-blocking-detection
+(defn- system-blocking-detection-config
   "Try retrieving BlockingInAsyncDetection mode from environment 
    variable `FDB_BLOCKING_DETECTION`"
   []
@@ -121,7 +121,7 @@
   (^FDBDatabase []
    (db-from-instance nil nil))
   (^FDBDatabase [cluster-file executor]
-   (db-from-instance cluster-file executor (default-blocking-detection)))
+   (db-from-instance cluster-file executor (system-blocking-detection-config)))
   (^FDBDatabase [^String cluster-file ^Executor executor blocking-in-async-detection]
    (let [^FDBDatabaseFactory factory (FDBDatabaseFactory/instance)]
      (when blocking-in-async-detection


### PR DESCRIPTION
`store/db-from-instance` is taking a new arity that can be used to define whether or not blocking calls in asynchronous context should be detected
When other arities are used, detection mode is retrieved from the environment variable `FDB_BLOCKING_DETECTION`.
If this environment variable does not exist, blocking detection mechanism is disabled