### PR TITLE
Ensure wrapped-runner uses open-mode

### DIFF
--- a/src/exoscale/vinyl/store.clj
+++ b/src/exoscale/vinyl/store.clj
@@ -223,7 +223,8 @@
 
 (defn wrapped-runner
   [db opts]
-  (let [runner (-> (new-runner db) (runner-opts opts))]
+  (let [runner (-> (new-runner db) (runner-opts opts))
+        open-mode (or (:open-mode db) :create-or-open)]
     (reify
       DatabaseContext
       (get-metadata [_] (get-metadata db))
@@ -237,7 +238,7 @@
               (store-from-builder
                (::builder db)
                context
-               :create-or-open
+               open-mode
                true)
                            (fn/make-fun f))))))
       (run-in-context [_ f]
@@ -248,7 +249,7 @@
              (f (store-from-builder
                  (::builder db)
                  context
-                 :create-or-open
+                 open-mode
                  true))))))
       AutoCloseable
       (close [_] (.close runner)))))

--- a/test/exoscale/vinyl/demostore.clj
+++ b/test/exoscale/vinyl/demostore.clj
@@ -86,7 +86,7 @@
                           [:nested "location" "zip_code"]]}})
 
 (def demostore
-  (store/initialize :demostore (Demostore/getDescriptor) schema))
+  (store/initialize :demostore (Demostore/getDescriptor) schema {:open-mode :build}))
 
 (defn create+start [schema opts]
   (let [demostore (store/initialize :demostore (Demostore/getDescriptor) schema opts)]


### PR DESCRIPTION
## Description

This ensures the `open-mode` is propagated to the operations that use `wrapped-runner`.

PS : Feel free to add commits on top of this PR instead of suggesting changes.