### PR TITLE
OnlineIndexer - support more parameters

### DIFF
--- a/src/exoscale/vinyl/store.clj
+++ b/src/exoscale/vinyl/store.clj
@@ -708,7 +708,7 @@
 
   Param key                 | Description
   | ---                     | ---
-  | `limit`                 | Default number of records to attempt to run in a single transaction. Defaults to 100
+  | `limit`                 | Default number of records to attempt to process in a single transaction. Defaults to 100
   | `records-per-second`    | Default limit to the number of records to attempt in a single second. Defaults to 10'000
   | `max-retries`           | Default number of times to retry a single range rebuild. Defaults to 100
   | `progress-log-interval` | Default interval to be logging successful progress in millis when building across transactions (-1 will not log). Defaults to 10'000 milliseconds

--- a/test/exoscale/vinyl/reindex_test.clj
+++ b/test/exoscale/vinyl/reindex_test.clj
@@ -1,0 +1,62 @@
+(ns exoscale.vinyl.reindex-test
+  (:require  [clojure.test :refer [is deftest] :as test]
+
+             [exoscale.vinyl.demostore  :as ds :refer [*db*]]
+             [exoscale.vinyl.store      :as store]
+             [exoscale.vinyl.payload    :as p]
+             [exoscale.vinyl.tuple      :as tuple]))
+
+(test/use-fixtures :each ds/with-create-fdb)
+
+(defn- refcounting-frequencies
+  ([] (refcounting-frequencies #{}))
+  ([removed]
+   (let [fixtures (remove (fn [{:keys [id]}] (removed id)) (:Invoice ds/fixtures))]
+     (frequencies (mapcat #(map (fn [line] (:product line)) (:lines %)) fixtures)))))
+
+(defn- scan-refcounting-index
+  ([] (scan-refcounting-index tuple/all))
+  ([range]
+   (let [entries @(store/scan-index *db* "refcount_index" ::store/by-group
+                                    range nil {::store/list? true})]
+     (into {}
+           (map (juxt #(second (.getKey %)) #(tuple/get-long (.getValue %))) entries)))))
+
+(deftest reindex-test
+  (is (= (refcounting-frequencies)
+         (scan-refcounting-index)))
+
+  (store/reindex *db* "refcount_index" {::store/progress-log-interval 1})
+  (store/reindex *db* "refcount_index" {::store/progress-log-interval 1})
+
+  (is (= (refcounting-frequencies)
+         (scan-refcounting-index))))
+
+(deftest scan-index-test
+  (store/insert-record *db* (p/object->record {:bucket "bucket" :path "path" :size 2}))
+
+  (is (= (assoc (refcounting-frequencies) "bucket" 1)
+         (scan-refcounting-index)))
+  (store/delete-record *db* :Invoice [1 1])
+  (is (= (assoc (refcounting-frequencies #{1}) "bucket" 1)
+         (scan-refcounting-index)))
+  (store/delete-record *db* :Invoice [1 2])
+  (is (= (assoc (refcounting-frequencies #{1 2}) "bucket" 1)
+         (scan-refcounting-index)))
+  (store/delete-record *db* :Invoice [3 3])
+  (is (= (assoc (refcounting-frequencies #{1 2 3}) "bucket" 1)
+         (scan-refcounting-index)))
+  (store/delete-record *db* :Invoice [4 4])
+  (is (= (assoc (refcounting-frequencies #{1 2 3 4}) "bucket" 1)
+         (scan-refcounting-index (tuple/all-of ["refcount"]))))
+  (is (= #{"p1" "p2"}
+         (into #{} (map #(second (.getKey %))
+                        @(store/scan-index *db* "refcount_index" ::store/by-group
+                                           (tuple/all-of ["zero"]) nil {::store/list? true})))))
+  (store/delete-record *db* :Invoice [4 5])
+  (is (= #{"p1" "p2" "p4"}
+         (into #{} (map #(second (.getKey %))
+                        @(store/scan-index *db* "refcount_index" ::store/by-group
+                                           (tuple/all-of ["zero"]) nil {::store/list? true})))))
+  (is (= {"bucket" 1}
+         (scan-refcounting-index (tuple/all-of ["refcount"])))))

--- a/test/exoscale/vinyl/scan_test.clj
+++ b/test/exoscale/vinyl/scan_test.clj
@@ -6,7 +6,7 @@
             [exoscale.vinyl.demostore  :as ds :refer [*db*]]
             [exoscale.vinyl.tuple :as tuple]))
 
-(test/use-fixtures :once ds/with-open-fdb)
+(test/use-fixtures :once ds/with-build-fdb)
 
 (defn install-records
   [db paths]

--- a/test/exoscale/vinyl/sql_test.clj
+++ b/test/exoscale/vinyl/sql_test.clj
@@ -4,7 +4,7 @@
             [exoscale.vinyl.sql        :refer [list-query]]
             [exoscale.vinyl.demostore  :as ds :refer [*db*]]))
 
-(test/use-fixtures :once ds/with-open-fdb)
+(test/use-fixtures :once ds/with-build-fdb)
 
 (deftest query-test
   (let [opts {:exoscale.vinyl.store/transform p/parse-record}]

--- a/test/exoscale/vinyl/store_test.clj
+++ b/test/exoscale/vinyl/store_test.clj
@@ -3,11 +3,10 @@
             [exoscale.vinyl.payload    :as p]
             [exoscale.vinyl.store      :as store]
             [exoscale.vinyl.aggregates :as agg]
-            [exoscale.vinyl.demostore  :as ds :refer [*db*]]
-            [exoscale.vinyl.tuple      :as tuple])
+            [exoscale.vinyl.demostore  :as ds :refer [*db*]])
   (:import [java.util.concurrent ExecutionException]))
 
-(test/use-fixtures :each ds/with-open-fdb)
+(test/use-fixtures :once ds/with-build-fdb)
 
 (deftest liveness-test
   (testing "Things are set up correctly"
@@ -155,56 +154,3 @@
       (store/save-record-batch ds-creator (ds/all-records))
       (store/save-record-batch new-ds-writer (ds/all-records))
       (is @(store/list-query old-ds-reader [:User [:starts-with? :name "a1"]])))))
-
-(defn- refcounting-frequencies
-  ([] (refcounting-frequencies #{}))
-  ([removed]
-   (let [fixtures (remove (fn [{:keys [id]}] (removed id)) (:Invoice ds/fixtures))]
-     (frequencies (mapcat #(map (fn [line] (:product line)) (:lines %)) fixtures)))))
-
-(defn- scan-refcounting-index
-  ([] (scan-refcounting-index tuple/all))
-  ([range]
-   (let [entries @(store/scan-index *db* "refcount_index" ::store/by-group
-                                    range nil {::store/list? true})]
-     (into {}
-           (map (juxt #(second (.getKey %)) #(tuple/get-long (.getValue %))) entries)))))
-
-(deftest reindex-test
-  (is (= (refcounting-frequencies)
-         (scan-refcounting-index)))
-
-  (store/reindex *db* "refcount_index")
-  (store/reindex *db* "refcount_index")
-
-  (is (= (refcounting-frequencies)
-         (scan-refcounting-index))))
-
-(deftest scan-index-test
-  (store/insert-record *db* (p/object->record {:bucket "bucket" :path "path" :size 2}))
-
-  (is (= (assoc (refcounting-frequencies) "bucket" 1)
-         (scan-refcounting-index)))
-  (store/delete-record *db* :Invoice [1 1])
-  (is (= (assoc (refcounting-frequencies #{1}) "bucket" 1)
-         (scan-refcounting-index)))
-  (store/delete-record *db* :Invoice [1 2])
-  (is (= (assoc (refcounting-frequencies #{1 2}) "bucket" 1)
-         (scan-refcounting-index)))
-  (store/delete-record *db* :Invoice [3 3])
-  (is (= (assoc (refcounting-frequencies #{1 2 3}) "bucket" 1)
-         (scan-refcounting-index)))
-  (store/delete-record *db* :Invoice [4 4])
-  (is (= (assoc (refcounting-frequencies #{1 2 3 4}) "bucket" 1)
-         (scan-refcounting-index (tuple/all-of ["refcount"]))))
-  (is (= #{"p1" "p2"}
-         (into #{} (map #(second (.getKey %))
-                        @(store/scan-index *db* "refcount_index" ::store/by-group
-                                           (tuple/all-of ["zero"]) nil {::store/list? true})))))
-  (store/delete-record *db* :Invoice [4 5])
-  (is (= #{"p1" "p2" "p4"}
-         (into #{} (map #(second (.getKey %))
-                        @(store/scan-index *db* "refcount_index" ::store/by-group
-                                           (tuple/all-of ["zero"]) nil {::store/list? true})))))
-  (is (= {"bucket" 1}
-         (scan-refcounting-index (tuple/all-of ["refcount"])))))


### PR DESCRIPTION
## Description

This adds multiple parameters to the `reindex` function, in particular the one to ensure we are logging the progress of the re-indexation. It now defaults to 10 seconds (nothing used to be logged).

It also ensures FoundationDB is always empty between tests run by relying on the `FDB Java API` instead of Record Layer.
The __whole__ range is cleaned between and after the tests (in comparison to only the records).