### PR TITLE
long-index-transduce

### DIFF
--- a/src/exoscale/vinyl/store.clj
+++ b/src/exoscale/vinyl/store.clj
@@ -661,12 +661,12 @@
 
    Results being accumulated in memory, this also means that care must be
    taken with the accumulator."
-  [db xform f val index-name scan-type ^TupleRange range opts]
+  [db xform f init index-name scan-type ^TupleRange range opts]
   (let [props     (scan-properties opts)
         scan-type (as-scan-type scan-type)
         index     (-> db get-metadata (metadata-index index-name))]
     (continuation-traversing-transduce
-     db xform f val
+     db xform f init
      (fn [^FDBRecordStore store ^bytes cont]
        (.scanIndex store index scan-type range cont props))
      cursor/apply-transduce)))

--- a/src/exoscale/vinyl/store.clj
+++ b/src/exoscale/vinyl/store.clj
@@ -652,9 +652,9 @@
    (long-range-transduce db nil f val record-type items opts)))
 
 (defn long-index-transduce
-  "A transducer over large indices. Results
-   are reduced into an accumulator with the help of the reducing function `f`.
-   The accumulator is initiated to `init`. `clojure.core.reduced` is honored.
+  "A transducer over large indices.
+   Results are reduced into an accumulator with the help of the reducing function
+  `f`. The accumulator is initiated to `init`. `clojure.core.reduced` is honored.
 
    Obviously, this approach does away with any consistency guarantees usually
    offered by FDB.

--- a/test/exoscale/vinyl/reindex_test.clj
+++ b/test/exoscale/vinyl/reindex_test.clj
@@ -27,8 +27,8 @@
    (long-scan-refcounting-index tuple/all))
   ([range]
    (let [entries @(store/long-index-transduce *db* identity conj [] "refcount_index" ::store/by-group range {})]
-    (into {}
-          (map (juxt #(second (.getKey %)) #(tuple/get-long (.getValue %))) entries)))))
+     (into {}
+           (map (juxt #(second (.getKey %)) #(tuple/get-long (.getValue %))) entries)))))
 
 (deftest reindex-test
   (is (= (refcounting-frequencies)


### PR DESCRIPTION
## Description

FoundationDB Record Layer indices can get quite large, we need the ability to scan an index like any other kind of ranges (records, query). 