### PR TITLE
wrapper-runner/run-in-context should open FDB synchronously

### DIFF
--- a/src/exoscale/vinyl/store.clj
+++ b/src/exoscale/vinyl/store.clj
@@ -252,7 +252,7 @@
                  (::builder db)
                  context
                  open-mode
-                 true))))))
+                 false))))))
       AutoCloseable
       (close [_] (.close runner)))))
 


### PR DESCRIPTION
When creating a DatabaseContext with `wrapped-runner`, `run-in-context` was opening the database in asynchronous mode. This fix aligns the implementation with the `RecordStore` implementation.