### PR TITLE
add failing test for delete-all-records

### DIFF
--- a/test/exoscale/vinyl/delete_test.clj
+++ b/test/exoscale/vinyl/delete_test.clj
@@ -1,0 +1,16 @@
+(ns exoscale.vinyl.delete-test
+  (:require [clojure.test :as test]
+            [clojure.test :refer [deftest testing is]]
+            [exoscale.vinyl.demostore :as ds]
+            [exoscale.vinyl.demostore :as ds :refer [*db*]]
+            [exoscale.vinyl.payload :as p]
+            [exoscale.vinyl.store :as store]))
+
+(test/use-fixtures :each ds/with-build-fdb)
+
+(deftest delete
+  (testing "delete-all-records"
+    @(store/delete-all-records *db*)
+    (let [opts {::store/transform p/parse-record}]
+      (is (= []
+             @(store/list-query *db* [:User [:starts-with? :name "a1"]] opts))))))


### PR DESCRIPTION
The behavior of [deleteAllRecords](https://foundationdb.github.io/fdb-record-layer/api/fdb-record-layer-core/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.html#deleteAllRecords()) has changed between record layer 2.x and 4.x. We should investigate better the impact of upgrading the record layer library before moving back to version 4.x