### PR TITLE
revert breaking deps

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.0.2
+      uses: actions/checkout@v6.0.2
 
     ## This is optional but will speed up clojure steps
     - name: Cache mvn/git deps
-      uses: actions/cache@v3
+      uses: actions/cache@v5.0.4
       id: cache-deps
       with:
         path: |
@@ -32,9 +32,9 @@ jobs:
         apt-get -qyy install curl sudo
 
     - name: Install foundationdb
-      uses: foundationdb-rs/foundationdb-actions-install@v2.1.0
+      uses: foundationdb-rs/foundationdb-actions-install@v2.3.0
       with:
-        version: 6.3.23
+        version: 7.3.57
 
     - name: Check
       run: clojure -T:project check

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -32,9 +32,9 @@ jobs:
         apt-get -qyy install curl sudo
 
     - name: Install foundationdb
-      uses: foundationdb-rs/foundationdb-actions-install@v2.3.0
+      uses: foundationdb-rs/foundationdb-actions-install@v2.1.0
       with:
-        version: 7.3.57
+        version: 6.3.23
 
     - name: Check
       run: clojure -T:project check

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src"]
- :deps  {com.google.auto.service/auto-service       {:mvn/version "1.0.1"}
-         org.clojure/clojure                        {:mvn/version "1.11.1"}
-         org.clojure/tools.logging                  {:mvn/version "1.2.4"}
-         org.foundationdb/fdb-java                  {:mvn/version "6.3.24"}
+ :deps  {com.google.auto.service/auto-service       {:mvn/version "1.1.1"}
+         org.clojure/clojure                        {:mvn/version "1.12.4"}
+         org.clojure/tools.logging                  {:mvn/version "1.3.1"}
+         org.foundationdb/fdb-java                  {:mvn/version "7.3.57"}
          org.foundationdb/fdb-record-layer-core-pb3 {:mvn/version "2.8.110.0"}
-         com.google.protobuf/protobuf-java          {:mvn/version "3.21.2"}
-         com.stuartsierra/component                 {:mvn/version "1.1.0"}
-         exoscale/ex                                {:mvn/version "0.4.0"}
-         instaparse/instaparse                      {:mvn/version "1.4.12"}}
+         com.google.protobuf/protobuf-java          {:mvn/version "3.25.8"}
+         com.stuartsierra/component                 {:mvn/version "1.2.0"}
+         exoscale/ex                                {:mvn/version "0.4.2"}
+         instaparse/instaparse                      {:mvn/version "1.5.0"}}
 
  :exoscale.project/lib          com.exoscale/vinyl
  :exoscale.project/version-file "VERSION"
@@ -25,20 +25,20 @@
 
  :aliases
  {:test
-  {:extra-deps  {lambdaisland/kaocha    {:mvn/version "1.68.1059"}
-                 org.slf4j/slf4j-api    {:mvn/version "2.0.0-alpha7"}
-                 org.slf4j/slf4j-simple {:mvn/version "2.0.0-alpha7"}
-                 org.clojure/test.check {:mvn/version "1.1.1"}}
+  {:extra-deps  {lambdaisland/kaocha    {:mvn/version "1.91.1392"}
+                 org.slf4j/slf4j-api    {:mvn/version "2.0.17"}
+                 org.slf4j/slf4j-simple {:mvn/version "2.0.17"}
+                 org.clojure/test.check {:mvn/version "1.1.3"}}
    :extra-paths ["test" "test/resources" "target/classes"]
    :exec-fn     kaocha.runner/exec-fn}
 
   :prep
-  {:deps        {io.github.clojure/tools.build {:git/tag "v0.8.2"
-                                                :git/sha "ba1a2bf"}}
+  {:deps        {io.github.clojure/tools.build {:git/tag "v0.10.13"
+                                                :git/sha "ae52edf"}}
    :extra-paths ["protobuf"]
    :ns-default  build}
 
   :project
   {:deps       {io.github.exoscale/tools.project
-                {:git/sha "5f24196ebea4dc6e601d201d97b463ea26923c7e"}}
+                {:git/sha "27cac247ba6189617bdd4e135b9fd9396ba46a62"}}
    :ns-default exoscale.tools.project}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src"]
- :deps  {com.google.auto.service/auto-service   {:mvn/version "1.1.1"}
-         org.clojure/clojure                    {:mvn/version "1.12.3"}
-         org.clojure/tools.logging              {:mvn/version "1.3.0"}
-         org.foundationdb/fdb-java              {:mvn/version "7.3.57"}
-         org.foundationdb/fdb-record-layer-core {:mvn/version "4.8.13.0"}
-         com.google.protobuf/protobuf-java      {:mvn/version "4.33.1"}
-         com.stuartsierra/component             {:mvn/version "1.2.0"}
-         exoscale/ex                            {:mvn/version "0.4.2"}
-         instaparse/instaparse                  {:mvn/version "1.5.0"}}
+ :deps  {com.google.auto.service/auto-service       {:mvn/version "1.0.1"}
+         org.clojure/clojure                        {:mvn/version "1.11.1"}
+         org.clojure/tools.logging                  {:mvn/version "1.2.4"}
+         org.foundationdb/fdb-java                  {:mvn/version "6.3.24"}
+         org.foundationdb/fdb-record-layer-core-pb3 {:mvn/version "2.8.110.0"}
+         com.google.protobuf/protobuf-java          {:mvn/version "3.21.2"}
+         com.stuartsierra/component                 {:mvn/version "1.1.0"}
+         exoscale/ex                                {:mvn/version "0.4.0"}
+         instaparse/instaparse                      {:mvn/version "1.4.12"}}
 
  :exoscale.project/lib          com.exoscale/vinyl
  :exoscale.project/version-file "VERSION"
@@ -25,20 +25,20 @@
 
  :aliases
  {:test
-  {:extra-deps  {lambdaisland/kaocha    {:mvn/version "1.91.1392"}
-                 org.slf4j/slf4j-api    {:mvn/version "2.0.17"}
-                 org.slf4j/slf4j-simple {:mvn/version "2.0.17"}
+  {:extra-deps  {lambdaisland/kaocha    {:mvn/version "1.68.1059"}
+                 org.slf4j/slf4j-api    {:mvn/version "2.0.0-alpha7"}
+                 org.slf4j/slf4j-simple {:mvn/version "2.0.0-alpha7"}
                  org.clojure/test.check {:mvn/version "1.1.1"}}
    :extra-paths ["test" "test/resources" "target/classes"]
    :exec-fn     kaocha.runner/exec-fn}
 
   :prep
-  {:deps        {io.github.clojure/tools.build {:git/tag "v0.10.11"
-                                                :git/sha "c6c670a"}}
+  {:deps        {io.github.clojure/tools.build {:git/tag "v0.8.2"
+                                                :git/sha "ba1a2bf"}}
    :extra-paths ["protobuf"]
    :ns-default  build}
 
   :project
   {:deps       {io.github.exoscale/tools.project
-                {:git/sha "27cac247ba6189617bdd4e135b9fd9396ba46a62"}}
+                {:git/sha "5f24196ebea4dc6e601d201d97b463ea26923c7e"}}
    :ns-default exoscale.tools.project}}}

--- a/test/exoscale/vinyl/store_test.clj
+++ b/test/exoscale/vinyl/store_test.clj
@@ -82,16 +82,16 @@
 
 (deftest query-plan-test
   (testing "Planned queries"
-    (ensure-plan [:User [:starts-with? :name "a1"]] "ISCAN(username {[a1],[a1]})")
-    (ensure-plan [:User [:= :name "a1"]] "ISCAN(username [[a1],[a1]])")
-    (ensure-plan [:User [:= :email "a1@exoscale.ch"]] "SCAN([IS User]) | QCFILTER email EQUALS a1@exoscale.ch")
-    (ensure-plan [:Account [:= :state "terminated"]] "ISCAN(account_state [[terminated],[terminated]])")
-    (ensure-plan [:Account [:not= :state "terminated"]] "SCAN(<,>) | TFILTER Account | QCFILTER state NOT_EQUALS terminated")
-    (ensure-plan [:Invoice [:= :id 3]] "SCAN([IS Invoice]) | QCFILTER id EQUALS 3")
-    (ensure-plan [:Invoice [:>= :id 3]] "SCAN([IS Invoice]) | QCFILTER id GREATER_THAN_OR_EQUALS 3")
-    (ensure-plan [:Invoice [:<= :id 3]] "SCAN([IS Invoice]) | QCFILTER id LESS_THAN_OR_EQUALS 3")
-    (ensure-plan [:City] "SCAN([IS City])")
-    (ensure-plan [:City [:nested :location [:= :name "Lausanne"]]] "SCAN(<,>) | TFILTER City | QCFILTER location/{name EQUALS Lausanne}")))
+    (ensure-plan [:User [:starts-with? :name "a1"]] "Index(username {[a1],[a1]})")
+    (ensure-plan [:User [:= :name "a1"]] "Index(username [[a1],[a1]])")
+    (ensure-plan [:User [:= :email "a1@exoscale.ch"]] "Scan([IS User]) | email EQUALS a1@exoscale.ch")
+    (ensure-plan [:Account [:= :state "terminated"]] "Index(account_state [[terminated],[terminated]])")
+    (ensure-plan [:Account [:not= :state "terminated"]] "Scan(<,>) | [Account] | state NOT_EQUALS terminated")
+    (ensure-plan [:Invoice [:= :id 3]] "Scan([IS Invoice]) | id EQUALS 3")
+    (ensure-plan [:Invoice [:>= :id 3]] "Scan([IS Invoice]) | id GREATER_THAN_OR_EQUALS 3")
+    (ensure-plan [:Invoice [:<= :id 3]] "Scan([IS Invoice]) | id LESS_THAN_OR_EQUALS 3")
+    (ensure-plan [:City] "Scan([IS City])")
+    (ensure-plan [:City [:nested :location [:= :name "Lausanne"]]] "Scan(<,>) | [City] | location/{name EQUALS Lausanne}")))
 
 (deftest aggregation-test
   (testing "Aggregation queries"


### PR DESCRIPTION
Since https://github.com/exoscale/vinyl/pull/38 shows we have broken compatibility with at least `deleteAllRecords`, we should revert the record layer version to 2.x and investigate the impact of moving to 4.x.

This PR reverts the changes in https://github.com/exoscale/vinyl/pull/36, but updates all deps to their latest non-breaking version. There is also no reason to move to protobuf-java 4.x yet, as record-layer itself [uses 3.x](https://github.com/FoundationDB/fdb-record-layer/blob/fda082458ce48d55163f28cdbe959fabb8da90db/gradle/libs.versions.toml#L51).